### PR TITLE
Changes for jackstraw v1.1

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -526,7 +526,7 @@ setGeneric("apply_snm", function(object, int.var=NULL, ...)
 #' their principal components (PCs).
 #'
 #' @param object \code{S4 object}: \code{\linkS4class{deSet}}
-#' @param PC a numeric vector of principal components of interest. Choose a subset of r significant PCs to be used.
+#' @param r1 a numeric vector of principal components of interest. Choose a subset of r significant PCs to be used.
 #' @param r a number (a positive integer) of significant principal components.
 #' @param s a number (a positive integer) of synthetic null variables. Out of m variables, s variables are independently permuted.
 #' @param B a number (a positive integer) of resampling iterations. There will be a total of s*B null statistics.
@@ -546,11 +546,11 @@ setGeneric("apply_snm", function(object, int.var=NULL, ...)
 #' varibles and their r PCs.
 #'
 #' You could specify a subset of significant PCs
-#' that you are interested in (PC). If PC is given, then this function computes
+#' that you are interested in r1. If PC is given, then this function computes
 #' statistical significance of association between m variables and PC, while
 #' adjusting for other PCs (i.e., significant PCs that are not your interest).
 #' For example, if you want to identify variables associated with 1st and 2nd
-#' PCs, when your data contains three significant PCs, set r=3 and PC=c(1,2). 
+#' PCs, when your data contains three significant PCs, set r=3 and r1=c(1,2). 
 #' 
 #' Please take a careful look at your data and use appropriate graphical and
 #' statistical criteria to determine a number of significant PCs, r. The number
@@ -596,17 +596,17 @@ setGeneric("apply_snm", function(object, int.var=NULL, ...)
 #' de_obj <- build_models(data = kidexpr, cov = cov, null.model = null_model,
 #'                       full.model = full_model)
 #' ## apply the jackstraw
-#' out = apply_jackstraw(de_obj, PC=1, r=1)
+#' out = apply_jackstraw(de_obj, r1=1, r=1)
 #' ## Use optional arguments
 #' ## For example, set s and B for a balance between speed of the algorithm and accuracy of p-values
-#' ## out = apply_jackstraw(dat, PC=1, r=1, s=10, B=1000, seed=5678)
+#' ## out = apply_jackstraw(dat, r1=1, r=1, s=10, B=1000, seed=5678)
 #'
 #' @seealso \code{\link{permutationPA}}
 #'
 #' @author Neo Christopher Chung \email{nc@@princeton.edu}
 #' @import jackstraw
 #' @export
-setGeneric("apply_jackstraw", function(object, PC = NULL, r = NULL, s = NULL, B = NULL,
+setGeneric("apply_jackstraw", function(object, r1 = NULL, r = NULL, s = NULL, B = NULL,
                                        covariate = NULL, verbose = TRUE, seed = NULL)
   standardGeneric("apply_jackstraw"))
 

--- a/R/deSet-methods.R
+++ b/R/deSet-methods.R
@@ -348,10 +348,10 @@ setMethod("apply_snm",
 #' @rdname apply_jackstraw
 setMethod("apply_jackstraw",
           signature = signature(object="deSet"),
-          function(object, PC = NULL, r = NULL, s = NULL, B = NULL,
+          function(object, r1 = NULL, r = NULL, s = NULL, B = NULL,
                    covariate = NULL, verbose = TRUE, seed = NULL) {
             dat <- exprs(object)
-            js <- jackstraw::jackstraw(dat, PC = PC, r = r, s = s, B = B,
+            js <- jackstraw::jackstraw.PCA(dat, r1 = r1, r = r, s = s, B = B,
                       covariate = covariate, verbose = verbose, seed = seed)
             return(js)
           })


### PR DESCRIPTION
1. while jackstraw::jackstraw() works, it'd be better to directly call jackstraw::jackstraw.PCA().
2. the old argument "PC" is now renamed as "r1". 